### PR TITLE
Update index.coffee

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -78,7 +78,10 @@ util = require 'util'
 					server: match[3]
 				@lookup addr, options, (err, parts) =>
 					if err?
-						return done err
+						if data == ''
+							return done err
+						else
+							parts = data
 
 					if options.verbose
 						done null, [


### PR DESCRIPTION
This fixes an error when TLD nic server successfully responses but some of subrequests to Referral Server or Registrar Whois causes an error. Before it caused error without any data returned but this patch makes whois return at least TLD server answer.

You can test this issue with `site.af`. TLD server returns an answer but subrequest to Registrar Whois causes timeout error. Now library gives error, but with this patch it will give result.